### PR TITLE
Use ∉ for "not in".

### DIFF
--- a/python.vim
+++ b/python.vim
@@ -16,6 +16,7 @@ syntax match pyNiceOperator "<=" conceal cchar=≤
 syntax match pyNiceOperator ">=" conceal cchar=≥
 syntax match pyNiceOperator "==" conceal cchar=≡
 syntax match pyNiceOperator "!=" conceal cchar=≠
+syntax match pyNiceOperator "\<not in\>" conceal cchar=∉
 
 syntax keyword pyNiceStatement lambda conceal cchar=λ
 


### PR DESCRIPTION
This patch should get the syntax correct.
