### PR TITLE
Added conceal text for Python "for" loop

### DIFF
--- a/after/syntax/python.vim
+++ b/after/syntax/python.vim
@@ -11,7 +11,7 @@ syntax keyword pythonOperator is
 syntax match pyNiceOperator "\<in\>" conceal cchar=∈
 syntax match pyNiceOperator "\<or\>" conceal cchar=∨
 syntax match pyNiceOperator "\<and\>" conceal cchar=∧
-syntax match pyNiceOperator "\<not " conceal cchar=¬
+syntax match pyNiceOperator "\<not\>" conceal cchar=¬
 syntax match pyNiceOperator "<=" conceal cchar=≤
 syntax match pyNiceOperator ">=" conceal cchar=≥
 syntax match pyNiceOperator "==" conceal cchar=≡
@@ -20,8 +20,11 @@ syntax match pyNiceOperator "\<not in\>" conceal cchar=∉
 
 syntax keyword pyNiceStatement lambda conceal cchar=λ
 
+syntax keyword pyNiceRepeat for conceal cchar=∀
+
 hi link pyNiceOperator Operator
 hi link pyNiceStatement Statement
+hi link pyNiceRepeat Repeat
 hi! link Conceal Operator
 
 set conceallevel=2


### PR DESCRIPTION
Using the forall ∀ symbol. 

Also changed the match pattern for Python "not" operator to deal with space issues. 
